### PR TITLE
Move MS Edge browser detection outside of windows block (to support linux)

### DIFF
--- a/frontend/src/pages/EntryPage.tsx
+++ b/frontend/src/pages/EntryPage.tsx
@@ -123,7 +123,6 @@ const EntryPage = (props: Props) => {
       const supportedBrowsers = {
         windows: {
           "internet explorer": ">12",
-          "microsoft edge": ">18",
         },
         safari: ">12",
         firefox: ">=60",
@@ -131,6 +130,7 @@ const EntryPage = (props: Props) => {
         chromium: ">=74",
         opera: ">=62",
         "samsung internet for android": ">=11.1.1.52",
+        "Microsoft Edge": ">18",
       };
       // Get current device.
       const device = deviceInfo();


### PR DESCRIPTION
fixes #9

Note: I haven't actually tested this but it's simple so I imagine it should work fine (although I'm confused about the capitalization, but per the bowser docs, it looks like they used capitalized strings so that's what I used)