### PR TITLE
Fix: Slider inside the ColorPicker did not budge if present color is set to 'Black'

### DIFF
--- a/frontend/src/modules/canvas/components/CanvasToolbar.tsx
+++ b/frontend/src/modules/canvas/components/CanvasToolbar.tsx
@@ -18,7 +18,7 @@ import React, {
   CSSProperties,
   Fragment,
 } from "react";
-import { ColorPicker } from 'material-ui-color';
+import { ColorPicker, createColor } from 'material-ui-color';
 import { FileUploadModal } from "../../../shared/components/FileUploadModal";
 import { canvasManager, CANVAS_MODE } from "../services/CanvasManager";
 import { useToolbarState } from "../services/ToolbarInteractor";
@@ -234,7 +234,7 @@ export const CanvasToolbar = (props: Props) => {
         <Fragment>
           <BoxCenter style={{ margin: "0 10px" }}>
             <ColorPicker
-            defaultValue="#000"
+            defaultValue={createColor("#000")}
             onChange={c => canvasManager.setColor(c)}
             value={color}
             palette={colorOptions} />

--- a/frontend/src/modules/canvas/components/CanvasToolbar.tsx
+++ b/frontend/src/modules/canvas/components/CanvasToolbar.tsx
@@ -235,7 +235,7 @@ export const CanvasToolbar = (props: Props) => {
           <BoxCenter style={{ margin: "0 10px" }}>
             <ColorPicker
             defaultValue="#000"
-            onChange={c => canvasManager.setColor('#' + c.hex)}
+            onChange={c => canvasManager.setColor(c)}
             value={color}
             palette={colorOptions} />
           </BoxCenter>

--- a/frontend/src/modules/canvas/services/CanvasManager.ts
+++ b/frontend/src/modules/canvas/services/CanvasManager.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "events";
 import { fabric } from "fabric";
 import { Canvas, IEvent, Object as FabricObject } from "fabric/fabric-impl";
 import { CanvasStateManager } from "./CanvasStateManager";
-import { Color } from "material-ui-color";
+import { Color, createColor } from "material-ui-color";
 
 export const CANVAS_ELEMENT_ID = "conference_canvas";
 
@@ -18,7 +18,7 @@ export enum CANVAS_MODE {
 
 export type CanvasToolbar = {
   mode: string;
-  color: string;
+  color: Color;
   brushWidth: number;
   selectedObject?: FabricObject;
 };
@@ -60,7 +60,7 @@ export class CanvasManager extends EventEmitter {
     super();
     this.toolbar = {
       mode: CANVAS_MODE.FREEDRAW,
-      color: "#000",
+      color: createColor("#000"),
       brushWidth: 7,
     };
     this.mouse = {
@@ -163,15 +163,16 @@ export class CanvasManager extends EventEmitter {
     this.emit(CANVAS_TOPICS.TOOLBAR_CHANGED, this.canvasToolbar);
   }
 
-  setColor = (color: any) => {
+  setColor = (color: Color) => {
     const canvas = this.getCanvas();
-    canvas.freeDrawingBrush.color = '#'+color.hex;
+    const hex = '#' + color.hex;
+    canvas.freeDrawingBrush.color = hex;
     this.toolbar.color = color;
     if (this.toolbar.selectedObject) {
       this.toolbar.selectedObject.set({
         fill:
-          this.toolbar.selectedObject.type === "line" ? color : "transparent",
-        stroke: color,
+          this.toolbar.selectedObject.type === "line" ? hex : "transparent",
+        stroke: hex,
       });
       this.onObjectModified(this.toolbar.selectedObject);
     }
@@ -227,7 +228,7 @@ export class CanvasManager extends EventEmitter {
   initializeCanvas(canvasJSON: any) {
     this.canvas = new fabric.Canvas(CANVAS_ELEMENT_ID);
     (window as any).canvas = this.canvas;
-    this.canvas.freeDrawingBrush.color = this.toolbar.color;
+    this.canvas.freeDrawingBrush.color = '#'+this.toolbar.color.hex;
     this.canvas.freeDrawingBrush.width = this.toolbar.brushWidth;
 
     this.canvas.isDrawingMode = false;

--- a/frontend/src/modules/canvas/services/CanvasManager.ts
+++ b/frontend/src/modules/canvas/services/CanvasManager.ts
@@ -3,6 +3,7 @@ import { fabric } from "fabric";
 import { Canvas, IEvent, Object as FabricObject } from "fabric/fabric-impl";
 import { CanvasStateManager } from "./CanvasStateManager";
 import { Color, createColor } from "material-ui-color";
+import { logger } from "../../../logger";
 
 export const CANVAS_ELEMENT_ID = "conference_canvas";
 

--- a/frontend/src/modules/canvas/services/CanvasManager.ts
+++ b/frontend/src/modules/canvas/services/CanvasManager.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "events";
 import { fabric } from "fabric";
 import { Canvas, IEvent, Object as FabricObject } from "fabric/fabric-impl";
 import { CanvasStateManager } from "./CanvasStateManager";
+import { Color } from "material-ui-color";
 
 export const CANVAS_ELEMENT_ID = "conference_canvas";
 
@@ -162,9 +163,9 @@ export class CanvasManager extends EventEmitter {
     this.emit(CANVAS_TOPICS.TOOLBAR_CHANGED, this.canvasToolbar);
   }
 
-  setColor = (color: string) => {
+  setColor = (color: any) => {
     const canvas = this.getCanvas();
-    canvas.freeDrawingBrush.color = color;
+    canvas.freeDrawingBrush.color = '#'+color.hex;
     this.toolbar.color = color;
     if (this.toolbar.selectedObject) {
       this.toolbar.selectedObject.set({


### PR DESCRIPTION
When the present color was set to "Black," there was a bug in the ColorPicker component that prevented the slider from moving.

If the onChange is called, an alpha value, which is a hsv color type, needs to be injected into the ColorPicker component. This necessity is reflected in the modified version.

I really hope this works.